### PR TITLE
feat(DEPENDENCIES): each file can specify its own dependencies

### DIFF
--- a/src/main/java/org/scijava/nativelib/BaseJniExtractor.java
+++ b/src/main/java/org/scijava/nativelib/BaseJniExtractor.java
@@ -163,6 +163,7 @@ public abstract class BaseJniExtractor implements JniExtractor {
 		// foolproof
 		String combinedPath = (libPath.equals("") || libPath.endsWith(NativeLibraryUtil.DELIM) ?
 				libPath : libPath + NativeLibraryUtil.DELIM) + mappedlibName;
+		extractDependenciesFor(combinedPath);
 		lib = libraryJarClass.getClassLoader().getResource(combinedPath);
 		if (null == lib) {
 			/*
@@ -193,7 +194,6 @@ public abstract class BaseJniExtractor implements JniExtractor {
 		if (null != lib) {
 			debug("URL is " + lib.toString());
 			debug("URL path is " + lib.getPath());
-			extractDependenciesFor(combinedPath);
 			return extractResource(getJniDir(), lib, mappedlibName);
 		}
 		debug("Couldn't find resource " + combinedPath);
@@ -231,13 +231,13 @@ public abstract class BaseJniExtractor implements JniExtractor {
 			for (String line; (line = reader.readLine()) != null;) {
 				if (line.startsWith("#")) continue;
 				final String file = base + line;
+				// extract its own deps first
+				extractDependenciesFor(file);
+				// extract the dep itself
 				final URL dep = this.getClass().getResource(file);
 				if (dep == null) {
 					debug("Not found: " + file);
 				} else {
-					// extract its own deps first
-					extractDependenciesFor(file);
-					// extract the dep itself
 					extractResource(getNativeDir(), dep, line);
 				}
 			}

--- a/src/main/java/org/scijava/nativelib/BaseJniExtractor.java
+++ b/src/main/java/org/scijava/nativelib/BaseJniExtractor.java
@@ -234,7 +234,7 @@ public abstract class BaseJniExtractor implements JniExtractor {
 				// extract its own deps first
 				extractDependenciesFor(file);
 				// extract the dep itself
-				final URL dep = this.getClass().getResource(file);
+				final URL dep = this.getClass().getClassLoader().getResource(file);
 				if (dep == null) {
 					debug("Not found: " + file);
 				} else {


### PR DESCRIPTION
This introduces the DEPENDENCIES feature.
The goal is to resolve issue https://github.com/scijava/native-lib-loader/issues/45

It allows to specify list of dependencies for every file, so that it is extracted into the same directory. 
This allows complex sets libraries to be embedded properly and used from JNI, without affecting existing functionality.

Usage:

- let's say you have file `libzoo.so` which depends on `libelephant.so` and `libtiger.so.1`
- store `libzoo.so` as you do normally, for instance into `linux_64` directory
- create file `libzoo.so.DEPENDENCIES` next to it, it's the **dependency descriptor**
- give it the following contents:
  ```
  libelephant.so
  libtiger.so.1
  ```
- add these two listed files next to the descriptor (= same path)

Then use as you normally do.

The descriptors are evaluated recursively, so every dependency can have its own dependency descriptor.